### PR TITLE
Fix when no data

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -177,8 +177,8 @@ class Client implements ClientInterface
             return [0, null, false, null];
         }
 
-        if ($response && $response->data) {
-            $data     = substr($response->data, 5);
+        if ($response) {
+            $data     = $response->data ? substr($response->data, 5) : '';
             $trailers = ['grpc-status' => $response->headers['grpc-status'] ?? '0', 'grpc-message' => $response->headers['grpc-message'] ?? ''];
 
             return [$response->streamId, $data, $response->pipeline, $trailers];


### PR DESCRIPTION
When there is no data, it could be also valid response in a case when error occured on server side, then server will send response with no data, but with grpc-status different than '0'.